### PR TITLE
Improve performance by reducing conversions and allocation

### DIFF
--- a/mli.go
+++ b/mli.go
@@ -66,6 +66,7 @@ There are many common ways to encode message lengths and this library attempts t
 package simplemli
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -232,16 +233,12 @@ func Decode(key string, b *[]byte) (int, error) {
 		}
 
 		// Check for edge case of 0 in hex format
-		if hex.EncodeToString(*b) == "00000000" {
+		if bytes.Count(*b, []byte{'0'}) == len(*b) {
 			return 0, nil
 		}
 
 		// Convert to integer from ASCII
-		s := fmt.Sprintf("%s", *b)
-		if s == "0000" {
-			return 0, nil
-		}
-		n, err := strconv.Atoi(s)
+		n, err := strconv.Atoi(string(*b))
 		if err != nil {
 			return 0, fmt.Errorf("unable to convert string values to integer - %s", err)
 		}

--- a/mli_benchmarks_test.go
+++ b/mli_benchmarks_test.go
@@ -29,6 +29,8 @@ func BenchmarkEncoding(b *testing.B) {
 	}
 	for _, k := range mliTypes {
 		b.Run("Encoding "+k, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_, _ = Encode(k, 1500)
 			}
@@ -36,6 +38,8 @@ func BenchmarkEncoding(b *testing.B) {
 
 		x, _ := Encode(k, 1500)
 		b.Run("Decoding "+k, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_, _ = Decode(k, &x)
 			}


### PR DESCRIPTION
Avoid a hex.EncodeToString conversion just to compare against
"00000000" and then later "0000", just by using bytes.Count(... '0')

While here, also added (*testing.B).ReportAllocs to each benchmark
to report allocations.

## Problem Statement
_What is the current behavior? Why and how does it need to change?_

Having examined this library's code and benchmarked it, we can reduce allocations by noticing
that instead of invoking hex.EncodetoString "00000000" and then skip the `if s == "0000"` check
and use string(*b) inside strconv.Atoi


## Description of Change
_Please include a summary of the change and, if applicable, tag related issues, add code snippets or logs._

The benchmarking results https://dashboard.github.orijtech.com/benchmark/3319ffe57baa4553b37c704be8984aea show huge improvements in ~78% improvement in CPU time and also a huge reduction in allocations
![Screen Shot 2021-09-02 at 11 05 55 PM](https://user-images.githubusercontent.com/4898263/131958400-42f57f19-82ef-4344-ba05-9d30d90283c6.png)

/cc @cuonglm @kirbyquerby


## Breaking Change
_Is this a breaking change?_

No


## Caveats
_Please list any caveats or special considerations for this change._

None
