### PR TITLE
Adding GitHub Actions for Lint and Tests

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,38 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.29
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the action will use pre-installed Go.
+          # skip-go-installation: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: tests
+
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.16'
+    - name: Execute Tests
+      run: make tests


### PR DESCRIPTION
## Problem Statement
_What is the current behavior? Why and how does it need to change?_

Currently this repository is using Travis CI and due to some of the ways Travis CI has changed their support for Open Source projects it seems like it may be a challenge to use the Open Source tier in the future. 

## Description of Change
_Please include a summary of the change and, if applicable, tag related issues, add code snippets or logs._

This change adds two GitHub actions that will run on Pull Requests as well as the main/release branches. One will run `make tests` and the other will run the `golangci-lint` workflow.

At this time, I'm not removing the Travis configuration, as these can run in conjunction.

## Breaking Change
_Is this a breaking change?_

No

## Caveats
_Please list any caveats or special considerations for this change._

