### PR TITLE
Decode: use unsafe []byte->string conversion for discarded value

### DIFF
--- a/mli.go
+++ b/mli.go
@@ -71,6 +71,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strconv"
+	"unsafe"
 )
 
 // empty is used as a quick return during errors
@@ -238,7 +239,7 @@ func Decode(key string, b *[]byte) (int, error) {
 		}
 
 		// Convert to integer from ASCII
-		n, err := strconv.Atoi(string(*b))
+		n, err := strconv.Atoi(unsafeByteToStr(*b))
 		if err != nil {
 			return 0, fmt.Errorf("unable to convert string values to integer - %s", err)
 		}
@@ -247,6 +248,10 @@ func Decode(key string, b *[]byte) (int, error) {
 	default:
 		return 0, fmt.Errorf("Invalid MLI type provided")
 	}
+}
+
+func unsafeByteToStr(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
 }
 
 // Encode will accept a message length type and message length value desired. Encode will return a byte slice which


### PR DESCRIPTION
For Decode's MLI4I, we invoke strconv.Atoi after string(*b)
which incurs a []byte->string allocation. The converted []byte->string
is discarded so anyways it is okay to use unsafe, as the string is
never used again. You can see the results at https://dashboard.github.orijtech.com/benchmark/dbb0fca65f644d95bcf8d0c8caafc601

Results:

* time/op (ns/op)
Encoding/Decoding_2I-8	7.5ns ± 1%  6.7ns ± 0%  -10.36%	(p=0.000 n=10+9)
Encoding/Decoding_4E-8	8.8ns ± 0%  7.9ns ± 0%  -10.35%	(p=0.000 n=10+10)
Encoding/Decoding_A4E-8	38ns ± 1%   17ns ± 0%   -54.84%	(p=0.000 n=10+10)

* allocs/op (B/op)
Encoding/Decoding_A4E-8	4.0B ± 0%   0	-100.00% (p=0.000 n=10+10)

* allocs/op (N/op)
Encoding/Decoding_A4E-8	1.0 ± 0%    0	-100.00% (p=0.000 n=10+10)

Or visually
<img width="1354" alt="Screen Shot 2021-09-25 at 12 58 38 AM" src="https://user-images.githubusercontent.com/4898263/134762115-09575e1c-ce43-4c26-8976-551e41c1660e.png">


## Problem Statement
_What is the current behavior? Why and how does it need to change?_

string(*b) incurs a []byte->string allocation yet the value will be discarded.


## Description of Change
_Please include a summary of the change and, if applicable, tag related issues, add code snippets or logs._

This change removes a []byte->string allocation


## Breaking Change
_Is this a breaking change?_

No.


## Caveats
_Please list any caveats or special considerations for this change._

It uses unsafe, but the usage is isolated as we directly insert the converted string into strconv.Atoi, so this isn't  a caveat really. /cc @kirbyquerby @cuonglm @madflojo 