### PR TITLE
use constant name not value in documentation.

### DIFF
--- a/example/iso8583.go
+++ b/example/iso8583.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/americanexpress/simplemli"
+)
+
+func main() {
+
+	msg = []byte("this is an iso8583 message; not")
+
+	// reading MLI
+
+	b := make([]byte, simplemli.Size2I)
+
+}


### PR DESCRIPTION
## Problem Statement
Documentation is out of sync with code. Uses constant value and not constant name. 

## Description of Change
Changes all instances in documentation from value to constant name. 

## Breaking Change
not


Closes #5 
