### PR TITLE
chore(ci): updating ci badge and go version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,13 +19,13 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.18
 
     - name: Install cover
       run: go get golang.org/x/tools/cmd/cover
 
     - name: Install goveralls
-      run: go get -u github.com/mattn/goveralls
+      run: go install github.com/mattn/goveralls@latest
 
     - name: Test
       run: go test -race -v -covermode=atomic -coverprofile=coverage.out ./...

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Message Length Indicator Encoder/Decoder
 
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/americanexpress/simplemli)](https://pkg.go.dev/github.com/americanexpress/simplemli)
-[![Build Status](https://www.travis-ci.com/americanexpress/simplemli.svg?branch=main)](https://www.travis-ci.com/americanexpress/simplemli)
+[![Build](https://github.com/americanexpress/simplemli/actions/workflows/tests.yml/badge.svg)](https://github.com/americanexpress/simplemli/actions/workflows/tests.yml)
 [![Coverage Status](https://coveralls.io/repos/github/americanexpress/simplemli/badge.svg?branch=main)](https://coveralls.io/github/americanexpress/simplemli?branch=main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/americanexpress/simplemli)](https://goreportcard.com/report/github.com/americanexpress/simplemli)
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/americanexpress/simplemli
 
-go 1.16
+go 1.18


### PR DESCRIPTION
## Problem Statement
_What is the current behavior? Why and how does it need to change?_

The current CI badge needs to be fixed and pointed at the correct CI system.

## Description of Change
_Please include a summary of the change and, if applicable, tag related issues, add code snippets or logs._

I updated the CI Badge to work from GitHub Actions and bumped the Go version, as 1.16 was no longer viable for CI.

I bumped it to 1.18, the lowest version that can be supported.

## Breaking Change
_Is this a breaking change?_

Yes, moving from Go 1.16 to 1.18.

## Caveats
_Please list any caveats or special considerations for this change._

